### PR TITLE
remove `closure` arg from `.from_json`

### DIFF
--- a/lib/fetching.rb
+++ b/lib/fetching.rb
@@ -29,8 +29,8 @@ class Fetching
     value
   end
 
-  def self.from_json json, closure
-    from(JSON.parse json).__send__ closure
+  def self.from_json json
+    from(JSON.parse json)
   end
 
   def initialize table

--- a/spec/fetching_spec.rb
+++ b/spec/fetching_spec.rb
@@ -35,12 +35,6 @@ describe Fetching do
     end
   end
 
-  describe "a bad closure" do
-    it "raises the expected error" do
-      expect { Fetching.from_json("{}", :not_a_key) }.to raise_error(NoMethodError)
-    end
-  end
-
   it "has a nice #to_s" do
     nice_to_s = "{:one=>1, :two=>{\"two\"=>2}, :ary=>[1, 2], :object_ary=>[{}, {:three=>3}]}"
     expect(subject.to_s).to eq(nice_to_s)
@@ -50,6 +44,12 @@ describe Fetching do
     table = "{:one=>1, :two=>{\"two\"=>2}, :ary=>[1, 2], :object_ary=>[{}, {:three=>3}]}"
     nice_inspect = "#<Fetching::FetchingHash: @table=#{table}>"
     expect(subject.inspect).to eq(nice_inspect)
+  end
+
+  specify ".from_json" do
+    json     = '{ "some_key": 1 }'
+    expected = Fetching(JSON.parse(json))
+    expect(described_class.from_json(json)).to eq(expected)
   end
 
 end


### PR DESCRIPTION
You don't need this.  Instead do:

```
Fetching.from_json(your_json).your_closure
```
