### PR TITLE
removes some unused methods from the WHITELIST

### DIFF
--- a/lib/fetching.rb
+++ b/lib/fetching.rb
@@ -14,9 +14,8 @@ class Fetching
 
   WHITELIST = %w(
     class object_id == equal?
-    define_singleton_method instance_eval
+    define_singleton_method
     respond_to?
-    instance_variables instance_variable_get
     nil?
   )
 


### PR DESCRIPTION
instance_eval, instance_variables, instance_variable_get

The specs pass without them. I don't remember why they were needed.