### PR TITLE
Yield to a block on unknown attributes

### DIFF
--- a/lib/fetching/fetching_hash.rb
+++ b/lib/fetching/fetching_hash.rb
@@ -20,8 +20,12 @@ class Fetching
       end
     end
 
-    def method_missing(key, *_args, &_block)
-      fail NoMethodError, "#{key} not found\nyou have:\n#{@table.inspect}"
+    def method_missing(key, *_args)
+      if block_given?
+        yield
+      else
+        fail NoMethodError, "#{key} not found\nyou have:\n#{@table.inspect}"
+      end
     end
 
   end

--- a/spec/fetching/fetching_hash_spec.rb
+++ b/spec/fetching/fetching_hash_spec.rb
@@ -1,5 +1,10 @@
 RSpec.describe Fetching::FetchingHash do
 
+  specify 'using a block as the default value' do
+    hash = Fetching(one: 1)
+    expect(hash.two { 2 }).to eq(2)
+  end
+
   specify 'a Fetching object as a value' do
     ary = Fetching([1, 2])
     hsh = Fetching(one: 1)


### PR DESCRIPTION
Allow usage like:

```ruby
f = Fetching(one: 1)
f.two { 2 } #=> 2
```

Without this change the block is ignored, and that code raises.