### PR TITLE
Support for first(n)

### DIFF
--- a/lib/fetching/fetching_array.rb
+++ b/lib/fetching/fetching_array.rb
@@ -13,8 +13,10 @@ class Fetching
       end
     end
 
-    def first
-      self[0]
+    def first(num = 0)
+      return self[0] if num.zero?
+
+      num.times.map { |i| self[i] }
     end
 
     module ArrayMethods

--- a/spec/fetching/fetching_array_spec.rb
+++ b/spec/fetching/fetching_array_spec.rb
@@ -21,10 +21,20 @@ RSpec.describe Fetching::FetchingArray do
     end
   end
 
-  specify '#first' do
-    ary = []
-    sassy_ary = Fetching(ary)
-    expect { sassy_ary.first }.to raise_error(IndexError)
+  describe '#first' do
+    it 'returns the first element in the array' do
+      ary = []
+      sassy_ary = Fetching(ary)
+      expect { sassy_ary.first }.to raise_error(IndexError)
+    end
+
+    context 'when passed an amount to fetch the first of' do
+      it 'returns the first n elements' do
+        ary = [1, 2, 3]
+        sassy_ary = Fetching(ary)
+        expect(sassy_ary.first(2)).to eq([1, 2])
+      end
+    end
   end
 
   describe 'array methods' do


### PR DESCRIPTION
@mikegee 

This should Resolve #13.

It uses the same pattern as Array#first that accepts an argument.

The first `n` elements of the array are returned, each of them has
  the potential to raise an IndexError.

Example:

```ruby
arr = Fetching([1,2,3])
arr.first(2)
=> [1,2]
arr.first(5)
=> IndexError: index 3 outside of array bounds: -3...3
```