### PR TITLE
Multiple param support for values_at and []

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,18 +21,9 @@ Style/EmptyLinesAroundBlockBody:
 Metrics/LineLength:
   Max: 100
 
-<<<<<<< HEAD
 Style/RegexpLiteral:
-=======
-RegexpLiteral:
->>>>>>> Update rubocop syntax for new version
   Exclude:
     - Guardfile
 
 Style/TrailingCommaInLiteral:
-<<<<<<< HEAD
-=======
-  EnforcedStyleForMultiline: comma
-Style/TrailingCommaInArguments:
->>>>>>> Update rubocop syntax for new version
   EnforcedStyleForMultiline: comma

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,11 +1,10 @@
-require: rubocop-rspec
-
 AllCops:
   Include:
     - Gemfile
     - Guardfile
     - Rakefile
     - fetching.gemspec
+    - rubocop-rspec
 
 Style/Documentation:
   Enabled: false
@@ -22,9 +21,18 @@ Style/EmptyLinesAroundBlockBody:
 Metrics/LineLength:
   Max: 100
 
+<<<<<<< HEAD
 Style/RegexpLiteral:
+=======
+RegexpLiteral:
+>>>>>>> Update rubocop syntax for new version
   Exclude:
     - Guardfile
 
 Style/TrailingCommaInLiteral:
+<<<<<<< HEAD
+=======
+  EnforcedStyleForMultiline: comma
+Style/TrailingCommaInArguments:
+>>>>>>> Update rubocop syntax for new version
   EnforcedStyleForMultiline: comma

--- a/lib/fetching/fetching_array.rb
+++ b/lib/fetching/fetching_array.rb
@@ -51,21 +51,23 @@ class Fetching
       end
 
       def values_at(*args)
-        result = args.map do |arg|
-          case arg
-          when Integer
-            values_at_integer(arg)
-          when Array
-            values_at_array(arg)
-          when Range
-            values_at_range(arg)
-          end
-        end.flatten
+        results = args.map { |arg| result_for_argument(arg) }.flatten
 
-        Fetching.from(result)
+        Fetching.from(results)
       end
 
       private
+
+      def result_for_argument(argument)
+        case argument
+        when Integer
+          values_at_integer(argument)
+        when Array
+          values_at_array(argument)
+        when Range
+          values_at_range(argument)
+        end
+      end
 
       def values_at_integer(integer)
         self[integer]

--- a/lib/fetching/fetching_array.rb
+++ b/lib/fetching/fetching_array.rb
@@ -3,8 +3,12 @@ class Fetching
 
     include Enumerable
 
-    def [](index)
-      Fetching.from @table.fetch(index)
+    def [](*args)
+      if args.length == 1 && args.first.is_a?(Integer)
+        Fetching.from @table.fetch(args.first)
+      else
+        values_at(*args)
+      end
     end
 
     def each
@@ -47,9 +51,33 @@ class Fetching
       end
 
       def values_at(*args)
-        Fetching.from(args.map { |i| self[i] })
+        result = args.map do |arg|
+          case arg
+          when Integer
+            values_at_integer(arg)
+          when Array
+            values_at_array(arg)
+          when Range
+            values_at_range(arg)
+          end
+        end.flatten
+
+        Fetching.from(result)
       end
 
+      private
+
+      def values_at_integer(integer)
+        self[integer]
+      end
+
+      def values_at_array(array)
+        array.map { |a| values_at_integer(a) }
+      end
+
+      def values_at_range(range)
+        values_at_array(range.to_a)
+      end
     end
 
     include ArrayMethods

--- a/spec/fetching/fetching_array_spec.rb
+++ b/spec/fetching/fetching_array_spec.rb
@@ -148,13 +148,12 @@ RSpec.describe Fetching::FetchingArray do
 
         it 'correctly throws when range exceeds array' do
           range = (0..5)
-          values = Fetching(array.values_at(range))
           expect { fetching.values_at(range) }.to raise_error(IndexError)
         end
       end
 
       context 'with multiple ranges' do
-        let(:array)    { [1, 2, 3, 4, 5] }
+        let(:array) { [1, 2, 3, 4, 5] }
 
         it 'returns the proper values' do
           range_1 = (0..2)
@@ -167,7 +166,6 @@ RSpec.describe Fetching::FetchingArray do
         it 'correctly throws when range exceeds array' do
           range_1 = (0..2)
           range_2 = (2..7)
-          values = Fetching(array.values_at(range_1, range_2))
           expect { fetching.values_at(range_1, range_2) }.to raise_error(IndexError)
         end
       end

--- a/spec/fetching/fetching_array_spec.rb
+++ b/spec/fetching/fetching_array_spec.rb
@@ -37,6 +37,54 @@ RSpec.describe Fetching::FetchingArray do
     end
   end
 
+  describe '#[]' do
+    let(:array)    { [1, 2, 3] }
+    let(:fetching) { Fetching(array) }
+
+    it 'returns the specified index' do
+      expect(fetching[0]).to eq(1)
+      expect(fetching[1]).to eq(2)
+      expect(fetching[2]).to eq(3)
+    end
+
+    it 'throws an error on an invalid index' do
+      expect { fetching[5] }.to raise_error(IndexError)
+    end
+
+    context 'with multiple values' do
+      it 'returns a fetching array of the results' do
+        expected = Fetching([1, 2])
+        expect(fetching[0, 1]).to eq(expected)
+      end
+
+      it 'raises error on invalid index' do
+        expect { fetching[0, 5] }.to raise_error(IndexError)
+      end
+    end
+
+    context 'with a Range' do
+      it 'returns a fetching array of the results' do
+        expected = Fetching([1, 2])
+        expect(fetching[0..1]).to eq(expected)
+      end
+
+      it 'raises error on invalid index' do
+        expect { fetching[0..5] }.to raise_error(IndexError)
+      end
+    end
+
+    context 'with multiple ranges' do
+      it 'returns a fetching array of the results' do
+        expected = Fetching([1, 2, 3, 3])
+        expect(fetching[0..2, 2..2]).to eq(expected)
+      end
+
+      it 'raises error on invalid index' do
+        expect { fetching[0..1, 5..5] }.to raise_error(IndexError)
+      end
+    end
+  end
+
   describe 'array methods' do
     let(:array)    { [1, 2, 3] }
     let(:fetching) { Fetching(array) }
@@ -84,13 +132,45 @@ RSpec.describe Fetching::FetchingArray do
         values = Fetching(array.values_at(*at))
         expect(fetching.values_at(*at)).to eq(values)
       end
+
       specify 'out of bounds' do
         at = 5
         expected_message = /\Aindex #{at} out/
         expect { fetching.values_at(at) }.to raise_error(IndexError, expected_message)
       end
+
+      context 'with a range' do
+        it 'returns the expected values' do
+          range = (0..2)
+          values = Fetching(array.values_at(range))
+          expect(fetching.values_at(range)).to eq(values)
+        end
+
+        it 'correctly throws when range exceeds array' do
+          range = (0..5)
+          values = Fetching(array.values_at(range))
+          expect { fetching.values_at(range) }.to raise_error(IndexError)
+        end
+      end
+
+      context 'with multiple ranges' do
+        let(:array)    { [1, 2, 3, 4, 5] }
+
+        it 'returns the proper values' do
+          range_1 = (0..2)
+          range_2 = (2..4)
+          expected = Fetching([1, 2, 3, 3, 4, 5])
+          values = Fetching(array.values_at(range_1, range_2))
+          expect(values).to eq(expected)
+        end
+
+        it 'correctly throws when range exceeds array' do
+          range_1 = (0..2)
+          range_2 = (2..7)
+          values = Fetching(array.values_at(range_1, range_2))
+          expect { fetching.values_at(range_1, range_2) }.to raise_error(IndexError)
+        end
+      end
     end
-
   end
-
 end


### PR DESCRIPTION
@mikegee 
Resolves #9

Both the `values_at` and `[]` methods now behave
  more Array like.

```ruby
fetching = Fetching([1, 2, 3])
fetching[0]
=> 1
fetching.values_at(0..1)
=> [1, 2]
fetching.values_at(2)
=> 3
fetching.values_at(0, 2)
=> [1, 3]
fetching[0..5]
=> IndexError
```

And more!

Supporting specs have also been added.