### PR TITLE
Fix Rubocop Problems

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ AllCops:
     - Rakefile
     - fetching.gemspec
 
-Documentation:
+Style/Documentation:
   Enabled: false
 
 Style/EmptyLinesAroundClassBody:
@@ -22,10 +22,9 @@ Style/EmptyLinesAroundBlockBody:
 Metrics/LineLength:
   Max: 100
 
-RegexpLiteral:
-  MaxSlashes: 0
+Style/RegexpLiteral:
   Exclude:
     - Guardfile
 
-TrailingComma:
+Style/TrailingCommaInLiteral:
   EnforcedStyleForMultiline: comma

--- a/fetching.gemspec
+++ b/fetching.gemspec
@@ -28,10 +28,10 @@ HEREDOC
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '~> 3.1.0'
-  spec.add_development_dependency 'rubocop'
+  spec.add_development_dependency 'rubocop', '~> 0.37.0'
   spec.add_development_dependency 'rubocop-rspec'
   unless ENV['CI']
-    spec.add_development_dependency 'pry-plus'
+    spec.add_development_dependency 'pry'
     spec.add_development_dependency 'guard-rspec'
     spec.add_development_dependency 'guard-rubocop'
   end

--- a/lib/fetching.rb
+++ b/lib/fetching.rb
@@ -17,7 +17,7 @@ class Fetching
     define_singleton_method singleton_class
     respond_to?
     nil?
-  )
+  ).freeze
 
   all_methods = instance_methods.map(&:to_s).grep(/\A[^_]/)
   (all_methods - WHITELIST).each(&method(:undef_method))
@@ -30,7 +30,7 @@ class Fetching
   end
 
   def self.from_json(json)
-    from(JSON.parse json)
+    from JSON.parse(json)
   end
 
   def initialize(table)

--- a/lib/fetching/fetching_array.rb
+++ b/lib/fetching/fetching_array.rb
@@ -16,7 +16,7 @@ class Fetching
     def first(num = 0)
       return self[0] if num.zero?
 
-      num.times.map { |i| self[i] }
+      Array.new(num) { |i| self[i] }
     end
 
     module ArrayMethods
@@ -28,7 +28,7 @@ class Fetching
       def length
         @table.length
       end
-      alias_method :size, :length
+      alias size length
 
       def reverse
         Fetching.from @table.reverse

--- a/lib/fetching/fetching_hash.rb
+++ b/lib/fetching/fetching_hash.rb
@@ -21,7 +21,7 @@ class Fetching
     end
 
     def method_missing(key, *_args, &_block)
-      fail NoMethodError, "#{key} not found\nyou have:\n#{@table.inspect}"
+      raise NoMethodError, "#{key} not found\nyou have:\n#{@table.inspect}"
     end
 
   end

--- a/lib/fetching/version.rb
+++ b/lib/fetching/version.rb
@@ -1,3 +1,3 @@
 class Fetching
-  VERSION = '0.6.1'
+  VERSION = '0.6.1'.freeze
 end

--- a/spec/fetching_spec.rb
+++ b/spec/fetching_spec.rb
@@ -34,12 +34,12 @@ RSpec.describe Fetching do
   end
 
   it 'has a nice #to_s' do
-    nice_to_s = "{:one=>1, :two=>{\"two\"=>2}, :ary=>[1, 2], :object_ary=>[{}, {:three=>3}]}"
+    nice_to_s = '{:one=>1, :two=>{"two"=>2}, :ary=>[1, 2], :object_ary=>[{}, {:three=>3}]}'
     expect(subject.to_s).to eq(nice_to_s)
   end
 
   it 'has a nice #inspect' do
-    table = "{:one=>1, :two=>{\"two\"=>2}, :ary=>[1, 2], :object_ary=>[{}, {:three=>3}]}"
+    table = '{:one=>1, :two=>{"two"=>2}, :ary=>[1, 2], :object_ary=>[{}, {:three=>3}]}'
     nice_inspect = "#<Fetching::FetchingHash: @table=#{table}>"
     expect(subject.inspect).to eq(nice_inspect)
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,7 +10,7 @@ RSpec.configure do |config|
   end
 
   if ENV['CI']
-    config.before(:example, :focus) { fail 'Should not commit focused specs' }
+    config.before(:example, :focus) { raise 'Should not commit focused specs' }
   else
     config.filter_run :focus
     config.run_all_when_everything_filtered = true


### PR DESCRIPTION
- upgrade rubocop
- specify version to prevent regressions as we automatically install the latest
- correct all the current offenses
- downgrade pry-plus to pry to avoid native extensions