### PR TITLE
Print keys available instead of entire object in error message.

### DIFF
--- a/lib/fetching/fetching_hash.rb
+++ b/lib/fetching/fetching_hash.rb
@@ -21,7 +21,7 @@ class Fetching
     end
 
     def method_missing(key, *_args, &_block)
-      raise NoMethodError, "#{key} not found\nyou have:\n#{@table.inspect}"
+      raise NoMethodError, "#{key} not found\nyou have:\n#{@table.keys.join(', ')}"
     end
 
   end

--- a/spec/fetching_spec.rb
+++ b/spec/fetching_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Fetching do
       expected_message = <<-EOM.gsub(/^ +/, '').strip
         not_a_key not found
         you have:
-        {:one=>1, :two=>{\"two\"=>2}, :ary=>[1, 2], :object_ary=>[{}, {:three=>3}]}
+        one, two, ary, object_ary
       EOM
 
       expect { subject.not_a_key }.to raise_error(NoMethodError, expected_message)


### PR DESCRIPTION
We don't want to print the entire object in the error message for a
couple of reasons:

1. Some of the objects may be large with multiple nested levels and it
can be difficult to look through when the entire object is printed in
the error message.
2. In the case where the fetching object contains sensitive data, sending
that data to third party services could be problematic.