### PR TITLE
Allow #tap method on Fetching objects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,10 @@ script:
   - bundle exec rubocop --display-cop-names
 sudo: false
 rvm:
-  - 1.9.3
-  - 2.0
-  - 2.1
-  - 2.2
-  - jruby
-  - rbx-2
+  - ruby-1.9.3-p551
+  - ruby-2.0.0-p648
+  - ruby-2.1.10
+  - ruby-2.2.7
+  - ruby-2.3.4
+  - ruby-2.4.1
+  - jruby-9.1.5.0

--- a/lib/fetching.rb
+++ b/lib/fetching.rb
@@ -16,7 +16,7 @@ class Fetching
     class object_id == equal?
     define_singleton_method singleton_class
     respond_to?
-    nil?
+    nil? tap
   ).freeze
 
   all_methods = instance_methods.map(&:to_s).grep(/\A[^_]/)

--- a/spec/fetching_spec.rb
+++ b/spec/fetching_spec.rb
@@ -33,6 +33,13 @@ RSpec.describe Fetching do
     end
   end
 
+  it 'can be #tap()ed' do
+    f = Fetching(foo: 'bar')
+    f.tap do |fetching_obj|
+      expect(fetching_obj).to eq(f)
+    end
+  end
+
   it 'has a nice #to_s' do
     nice_to_s = '{:one=>1, :two=>{"two"=>2}, :ary=>[1, 2], :object_ary=>[{}, {:three=>3}]}'
     expect(subject.to_s).to eq(nice_to_s)


### PR DESCRIPTION
I suppose some folks might want this, and there aren't too many FetchingHash instances with a `tap` key. ¯\\\_(ツ)_/¯

To my great surprise, Rails calls `#tap` on the return value of controller methods. This code raises:

```ruby
class WidgetsController < ApplicationController
  def show
    @widget = Fetching(name: 'My Widget')
  end
end
```

At least Rails 5 didn't work for us because of this line: https://github.com/rails/rails/blob/23aa0a2bb551717f153ac75f24c017c43ab853f2/actionpack/lib/action_controller/metal/basic_implicit_render.rb#L4