### PR TITLE
Periodic Maintenance

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,6 +15,14 @@ Layout/EmptyLinesAroundModuleBody:
 Layout/EmptyLinesAroundBlockBody:
   Enabled: false
 
+Layout/IndentHeredoc:
+  Exclude:
+    - fetching.gemspec
+
+Metrics/BlockLength:
+  Exclude:
+    - fetching.gemspec
+
 Metrics/LineLength:
   Max: 100
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,24 +6,21 @@ AllCops:
     - fetching.gemspec
     - rubocop-rspec
 
-Style/Documentation:
+Layout/EmptyLinesAroundClassBody:
   Enabled: false
 
-Style/EmptyLinesAroundClassBody:
+Layout/EmptyLinesAroundModuleBody:
   Enabled: false
 
-Style/EmptyLinesAroundModuleBody:
-  Enabled: false
-
-Style/EmptyLinesAroundBlockBody:
+Layout/EmptyLinesAroundBlockBody:
   Enabled: false
 
 Metrics/LineLength:
   Max: 100
 
+Style/Documentation:
+  Enabled: false
+
 Style/RegexpLiteral:
   Exclude:
     - Guardfile
-
-Style/TrailingCommaInLiteral:
-  EnforcedStyleForMultiline: comma

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,7 @@ script:
   - bundle exec rubocop --display-cop-names
 sudo: false
 rvm:
-  - ruby-1.9.3-p551
-  - ruby-2.0.0-p648
-  - ruby-2.1.10
-  - ruby-2.2.7
-  - ruby-2.3.4
-  - ruby-2.4.1
-  - jruby-9.1.5.0
+  - jruby-9.2
+  - ruby-2.3
+  - ruby-2.4
+  - ruby-2.5

--- a/Guardfile
+++ b/Guardfile
@@ -7,7 +7,7 @@ rspec_opts = {
   cmd:             'bundle exec rspec',
   all_on_start:    true,
   all_after_pass:  true,
-  failed_mode:     :keep,
+  failed_mode:     :keep
 }
 
 guard :rspec, rspec_opts do
@@ -24,7 +24,7 @@ guard :rspec, rspec_opts do
     [
       "spec/routing/#{m[1]}_routing_spec.rb",
       "spec/#{m[2]}s/#{m[1]}_#{m[2]}_spec.rb",
-      "spec/acceptance/#{m[1]}_spec.rb",
+      "spec/acceptance/#{m[1]}_spec.rb"
     ]
   end
   watch(%r{^spec/support/(.+)\.rb$})                  { 'spec' }

--- a/fetching.gemspec
+++ b/fetching.gemspec
@@ -1,5 +1,4 @@
-# coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'fetching/version'
 
@@ -15,7 +14,7 @@ This gem is a work in progress.  The implementation code is not what's
 important.  What is important: Don't de-serialize API responses in to
 hashes and arrays.  Use a "strict" object that inforces key presence,
 and array bounds.}
-HEREDOC
+  HEREDOC
 
   spec.homepage      = ''
   spec.license       = 'MIT'
@@ -31,8 +30,8 @@ HEREDOC
   spec.add_development_dependency 'rubocop', '~> 0.58.0'
   spec.add_development_dependency 'rubocop-rspec'
   unless ENV['CI']
-    spec.add_development_dependency 'pry'
     spec.add_development_dependency 'guard-rspec'
     spec.add_development_dependency 'guard-rubocop'
+    spec.add_development_dependency 'pry'
   end
 end

--- a/fetching.gemspec
+++ b/fetching.gemspec
@@ -27,8 +27,8 @@ HEREDOC
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'rspec', '~> 3.1.0'
-  spec.add_development_dependency 'rubocop', '~> 0.37.0'
+  spec.add_development_dependency 'rspec', '~> 3.1'
+  spec.add_development_dependency 'rubocop', '~> 0.58.0'
   spec.add_development_dependency 'rubocop-rspec'
   unless ENV['CI']
     spec.add_development_dependency 'pry'

--- a/fetching.gemspec
+++ b/fetching.gemspec
@@ -7,13 +7,11 @@ Gem::Specification.new do |spec|
   spec.version       = Fetching::VERSION
   spec.authors       = ['Michael Gee', 'Mark Lorenz']
   spec.email         = ['mgee@covermymeds.com', 'mlorenz@covermymeds.com']
-  spec.description   = 'More sass in more structs.'
+  spec.description   = "Strict wrapper for Hashes and Arrays that doesn't return nil"
 
   spec.summary       = <<-HEREDOC
-This gem is a work in progress.  The implementation code is not what's
-important.  What is important: Don't de-serialize API responses in to
-hashes and arrays.  Use a "strict" object that inforces key presence,
-and array bounds.}
+Don't de-serialize API responses in to hashes and arrays.
+Use a "strict" object that inforces key presence and array bounds.
   HEREDOC
 
   spec.homepage      = ''


### PR DESCRIPTION
- Upgrade RSpec and Rubocop
- Address new Rubocop offenses
- Fixup the gem's description and summary
- Drop support for Rubys beyond their end-of-life